### PR TITLE
flake: use the correct flake template while doing nix init

### DIFF
--- a/kd/src/main.rs
+++ b/kd/src/main.rs
@@ -512,7 +512,7 @@ fn main() {
             cmd.arg("flake")
                 .arg("init")
                 .arg("--template")
-                .arg("github:alberand/kd#x86_64-linux.default")
+                .arg("github:alberand/kd#default")
                 .current_dir(&path);
 
             if cli.debug {


### PR DESCRIPTION
doing kd init results in:
error: flake 'github:alberand/kd' does not provide attribute 'templates.x86_64-linux.default' or 'x86_64-linux.default'

Doing a bit inspection shows there are no template paths with x86_64-linux prefix. (Probably this commit might be the culprit: be474a142b59115df199fb8c944ec0582dd02f73)

Fix it by just using default as the only supported architecture is x86_64-linux.