### PR TITLE
lib: make tomlq as a necessary package for kd run

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -259,6 +259,7 @@ in rec {
               trace-cmd
               python312Packages.ply # b4 prep --check and ./script/checkpatch
               python312Packages.gitpython # b4 prep --check and ./script/checkpatch
+              tomlq
               (vmtest-deploy {})
 
               (callPackage (import ./kd/derivation.nix) {})
@@ -308,7 +309,6 @@ in rec {
               numactl
               guilt
               nix-prefetch-git
-              tomlq
               # probably better to move it to separate module
               sqlite
               openssl


### PR DESCRIPTION
Without tomlq package installed, kd run will result in the following error:
/nix/store/03ak13m9vb13p5z3h8kmjdrr4j815007-runner/bin/runner: line 23: tq: command not found

Add tomlq as a part of the linuxshell.